### PR TITLE
Use interfaceand export it

### DIFF
--- a/denops/tataku/interface.ts
+++ b/denops/tataku/interface.ts
@@ -1,16 +1,21 @@
 import { Denops } from "./deps.ts";
 
 export interface Collector {
-  run: (denops: Denops) => string[];
-  option: Record<string, unknown>;
+  run: (
+    denops: Denops,
+  ) => Promise<string[]>;
 }
 
 export interface Processor {
-  run: (denops: Denops, source: string[]) => string[];
-  option: Record<string, unknown>;
+  run: (
+    denops: Denops,
+    source: string[],
+  ) => Promise<string[]>;
 }
 
 export interface Emitter {
-  run: (denops: Denops, source: string[]) => void;
-  option: Record<string, unknown>;
+  run: (
+    denops: Denops,
+    source: string[],
+  ) => Promise<void>;
 }

--- a/denops/tataku/interface.ts
+++ b/denops/tataku/interface.ts
@@ -1,0 +1,16 @@
+import { Denops } from "./deps.ts";
+
+export interface Collector {
+  run: (denops: Denops) => string[];
+  option: Record<string, unknown>;
+}
+
+export interface Processor {
+  run: (denops: Denops, source: string[]) => string[];
+  option: Record<string, unknown>;
+}
+
+export interface Emitter {
+  run: (denops: Denops, source: string[]) => void;
+  option: Record<string, unknown>;
+}

--- a/denops/tataku/main.ts
+++ b/denops/tataku/main.ts
@@ -50,7 +50,7 @@ export async function main(denops: Denops): Promise<void> {
 
       for (const recipe of processor) {
         try {
-          pipe = await process(denops, recipe.name, recipe.options, pipe);
+          pipe = await process(denops, recipe.name, recipe.options ?? {}, pipe);
         } catch (err) {
           await handleError(denops, "processor", recipe.name, err);
           return;
@@ -58,7 +58,7 @@ export async function main(denops: Denops): Promise<void> {
       }
 
       try {
-        await emit(denops, emitter.name, emitter.options, pipe);
+        await emit(denops, emitter.name, emitter.options ?? {}, pipe);
       } catch (err) {
         await handleError(denops, "emitter", emitter.name, err);
         return;

--- a/denops/tataku/types.ts
+++ b/denops/tataku/types.ts
@@ -1,5 +1,3 @@
-import { Denops } from "./deps.ts";
-
 export type Recipe = {
   collector: RecipePage;
   processor: RecipePage[];
@@ -17,24 +15,3 @@ export type Query = {
   kind: Kind;
   name: string;
 };
-
-export type TatakuModule<T extends Collector | Processor | Emitter> = {
-  run: T;
-};
-
-export type Collector = (
-  denops: Denops,
-  options?: Record<string, unknown>,
-) => Promise<string[]>;
-
-export type Processor = (
-  denops: Denops,
-  source: string[],
-  options?: Record<string, unknown>,
-) => Promise<string[]>;
-
-export type Emitter = (
-  denops: Denops,
-  source: string[],
-  options?: Record<string, unknown>,
-) => Promise<void>;

--- a/denops/tataku/utils.test.ts
+++ b/denops/tataku/utils.test.ts
@@ -147,9 +147,9 @@ Deno.test({
       const x = { options: {} };
       assert(!isRecipePage(x), `Given: ${x}`);
     });
-    await t.step("If x does not have `options`, should return false", () => {
+    await t.step("If x does not have `options`, should return true", () => {
       const x = { name: "" };
-      assert(!isRecipePage(x), `Given: ${x}`);
+      assert(isRecipePage(x), `Given: ${x}`);
     });
   },
 });

--- a/denops/tataku/utils.ts
+++ b/denops/tataku/utils.ts
@@ -6,15 +6,8 @@ import {
   isString,
   isUndefined,
 } from "./deps.ts";
-import {
-  Collector,
-  Emitter,
-  Kind,
-  Processor,
-  Recipe,
-  RecipePage,
-  TatakuModule,
-} from "./types.ts";
+import { Kind, Recipe, RecipePage } from "./types.ts";
+import { Collector, Emitter, Processor } from "./interface.ts";
 
 /**
  * Return `true` if the type of `x` is `async function`.
@@ -57,7 +50,7 @@ export function isAsyncFunction(
  */
 export function isTatakuModule<T extends Collector | Processor | Emitter>(
   x: unknown,
-): x is TatakuModule<T> {
+): x is T {
   return isObject(x) && (isFunction(x.run) || isAsyncFunction(x.run));
 }
 

--- a/doc/tataku.txt
+++ b/doc/tataku.txt
@@ -98,38 +98,16 @@ FOR DEVELOPER						*tataku-for-developer*
 
 This section explain how to create module.
 
-When call recipe, tataku.vim import `@tataku/<module-type>/<module-name>.ts`
-from &runtimepath.
+When call recipe, tataku.vim import module from
+`denops/@tataku/<module-type>/<module-name>.ts` within &runtimepath.
 
-The module must export async function `run()`.
+The module must has class that are exported as default.
+The class must has two (or over than two) methods:
 
-* collector
-	Collector give two arguments.
-	* `denops: Denops`
-		denops.vim handler.
-	* `options: Record<string, unknown>`
-		options specified by user.
-	Collector must return `Promise<string[]>`
+* `constructor(option: Record<string, unknown>)`
+* `run(denops: Denops, source: string[])`
 
-* processor
-	Processor give three arguments.
-	* `denops: Denops`
-		denops.vim handler.
-	* `options: Record<string, unknown>`
-		options specified by user.
-	* `source: string[]`
-		processed array of string.
-	Processor must return `Promise<string[]>`
-
-* emitter
-	Emitter give three arguments.
-	* `denops: Denops`
-		denops.vim handler.
-	* `options: Record<string, unknown>`
-		options specified by user.
-	* `source: string[]`
-		processed array of string.
-	Emitter must return `Promise<void>`
+The interfaces are shown in `../denops/tataku/interface.ts`.
 
 ==============================================================================
 vim:tw=78:ts=8:ft=help:norl:noet:fen:fdl=0:


### PR DESCRIPTION
This PR provides interface of modules(`Collector`, `Processor`, `Emitter`).

There change is breaking one.

The definition of modules should change below:
(This sample is from Omochice/tataku-collector-current_line)

- Before
    ```typescript
    import { Denops } from "https://deno.land/x/denops_std@v3.8.1/mod.ts";
    import * as fn from "https://deno.land/x/denops_std@v3.8.1/function/mod.ts";

    export async function run(
      denops: Denops,
      options: Record<string, unkown>,
    ): Promise<string[]> {
      return [await fn.getline(denops, ".")];
    }
    ```

- after
    ```typescript
    export default class {
      constructor(_option: Record<string, unknown>) {
      }

      async run(denops: Denops) {
        return [await fn.getline(denops, ".")];
      }
    }
    ```


- :+1: Add module interface definitions
- :boom: Export interface
