### PR TITLE
ci: set `timeout-minutes`

### DIFF
--- a/.github/workflows/_check-actions.yml
+++ b/.github/workflows/_check-actions.yml
@@ -4,6 +4,7 @@ on: workflow_call
 
 jobs:
   check-actions:
+    timeout-minutes: 30
     name: Check github actions
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/_check-deno.yml
+++ b/.github/workflows/_check-deno.yml
@@ -4,6 +4,7 @@ on: workflow_call
 
 jobs:
   deno_fmt:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -12,6 +13,7 @@ jobs:
       - uses: denoland/setup-deno@041b854f97b325bd60e53e9dc2de9cb9f9ac0cba # v1.1.4
       - run: deno task fmt:check
   deno_check:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     needs: deno_fmt
     permissions:
@@ -21,6 +23,7 @@ jobs:
       - uses: denoland/setup-deno@041b854f97b325bd60e53e9dc2de9cb9f9ac0cba # v1.1.4
       - run: deno task check
   deno_lint:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     needs: deno_fmt
     permissions:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   docs:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/enable-renovate-auto-merge.yml
+++ b/.github/workflows/enable-renovate-auto-merge.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   enable-auto-merge:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   path-filter:
+    timeout-minutes: 30
     outputs:
       actions: ${{steps.changes.outputs.actions}}
       ts: ${{steps.changes.outputs.ts}}
@@ -40,6 +41,7 @@ jobs:
     permissions:
       contents: read
   status-check:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     needs:
       - check-actions

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   path-filter:
+    timeout-minutes: 30
     outputs:
       actions: ${{steps.changes.outputs.actions}}
       ts: ${{steps.changes.outputs.ts}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   release-please:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4.1.1


### PR DESCRIPTION
ssia


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a `timeout-minutes: 30` parameter to various GitHub Actions workflows to ensure jobs do not run indefinitely. This affects the following jobs:
    - `check-actions`
    - `deno_fmt`
    - `deno_check`
    - `deno_lint`
    - `docs`
    - `enable-auto-merge`
    - `path-filter`
    - `status-check`
    - `release-please`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->