### PR TITLE
refactor: use getregion instead

### DIFF
--- a/autoload/tataku.vim
+++ b/autoload/tataku.vim
@@ -20,11 +20,11 @@ function! tataku#_operator(recipe_name) abort
       return 'g@'
     endif
 
-    let l:tmp = @@
-    let l:v = s:visual_command_from_wise_name(a:000[0])
-    execute 'silent!' 'normal!' '`[' .. v .. '`]"@y'
-    let l:selected = split(@@, '\n')
-    let @@ = l:tmp
+    let l:selected = getregion(
+      \ getpos("'["),
+      \ getpos("']"),
+      \ #{ type: s:visual_command_from_wise_name(a:000[0]) }
+      \ )
 
     let l:recipe = s:get_recipe(s:recipe_name)
     if empty(l:recipe)


### PR DESCRIPTION
This commit eliminates the need to save registers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved text selection mechanism in visual mode for recipe processing
	- Enhanced reliability of text retrieval during operator execution

- **Refactor**
	- Simplified text selection logic by using a more direct method of retrieving selected text

<!-- end of auto-generated comment: release notes by coderabbit.ai -->