### PR TITLE
feat: accept awaitable factory

### DIFF
--- a/denops/tataku/load.ts
+++ b/denops/tataku/load.ts
@@ -91,7 +91,7 @@ export function loadProcessor(
     .andThen((path) => {
       return ResultAsync.fromPromise(
         import(path.href).then((e) => e.default),
-        (cause) => new Error(`Failed to processor-${name}`, { cause }),
+        (cause) => new Error(`Failed to load processor-${name}`, { cause }),
       );
     })
     .andThen((factory: unknown) => {
@@ -110,7 +110,7 @@ export function loadEmitter(
     .andThen((path) => {
       return ResultAsync.fromPromise(
         import(path.href).then((e) => e.default),
-        (cause) => new Error(`Failed to emitter-${name}`, { cause }),
+        (cause) => new Error(`Failed to load emitter-${name}`, { cause }),
       );
     })
     .andThen((factory: unknown) => {

--- a/denops/tataku/load.ts
+++ b/denops/tataku/load.ts
@@ -13,7 +13,7 @@ type Query = {
   name: string;
 };
 
-type Factory<T> = (denops: Denops, options: unknown) => T;
+type Factory<T> = (denops: Denops, options: unknown) => T | Promise<T>;
 
 function search(
   denops: Denops,

--- a/denops/tataku/utils.ts
+++ b/denops/tataku/utils.ts
@@ -35,3 +35,19 @@ export async function handleError(
     );
   }
 }
+
+/**
+ * Convert some value to Error
+ *
+ * @param cause Some error thing
+ * @param message The message of error if using cause is not Error
+ * @returns Converted error
+ */
+export function convertError(message = "Failed"): (e: unknown) => Error {
+  return (cause) => {
+    if (cause instanceof Error) {
+      return cause;
+    }
+    return new Error(message, { cause });
+  };
+}


### PR DESCRIPTION
Some provider needs to load config file from other resource as `Promise<T>`.

So we need change `Factory` to acceptable for `Promise`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced error handling with a new `convertError` utility function
  - Updated factory type to support asynchronous factory functions

- **Bug Fixes**
  - Improved error messages for loading processors and emitters
  - More robust error handling in stream preparation process

- **Refactor**
  - Standardized error conversion and reporting mechanisms
  - Updated promise resolution strategy for factory functions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->