### PR TITLE
build: stop to use `allow-slow-types`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,5 +33,5 @@ jobs:
       - uses: denoland/setup-deno@909cc5acb0fdd60627fb858598759246509fa755 # v2.0.2
         if: ${{ steps.release.outputs.release_created }}
       - name: Upload Release Artifact
-        run: deno publish --config jsr.json --allow-slow-types
+        run: deno publish --config jsr.json
         if: ${{ steps.release.outputs.release_created }}

--- a/denops/tataku/load.ts
+++ b/denops/tataku/load.ts
@@ -4,10 +4,8 @@ import { runtimepath } from "jsr:@denops/std@7.4.0/option";
 import { globpath } from "jsr:@denops/std@7.4.0/function";
 import { is } from "jsr:@core/unknownutil@4.3.0";
 import { join, toFileUrl } from "jsr:@std/path@1.0.8";
-import type { Collector, Emitter, Processor } from "./types.ts";
+import type { Collector, Emitter, Kind, Processor } from "./types.ts";
 import type { Factory } from "./export.ts";
-
-type Kind = "collector" | "processor" | "emitter";
 
 type Query = {
   kind: Kind;

--- a/denops/tataku/tataku.ts
+++ b/denops/tataku/tataku.ts
@@ -5,8 +5,8 @@ import {
   type Emitter,
   type Processor,
   type Recipe,
-  validate,
 } from "./types.ts";
+import { validate } from "./validate.ts";
 import { loadCollector, loadEmitter, loadProcessor } from "./load.ts";
 import { convertError } from "./utils.ts";
 

--- a/denops/tataku/tataku.ts
+++ b/denops/tataku/tataku.ts
@@ -1,11 +1,6 @@
 import type { Denops } from "jsr:@denops/std@7.4.0";
 import { err, ok, okAsync, Result, ResultAsync } from "npm:neverthrow@8.1.1";
-import {
-  type Collector,
-  type Emitter,
-  type Processor,
-  type Recipe,
-} from "./types.ts";
+import type { Collector, Emitter, Processor, Recipe } from "./types.ts";
 import { validate } from "./validate.ts";
 import { loadCollector, loadEmitter, loadProcessor } from "./load.ts";
 import { convertError } from "./utils.ts";

--- a/denops/tataku/types.ts
+++ b/denops/tataku/types.ts
@@ -1,17 +1,13 @@
-import { as, is, type PredicateType } from "jsr:@core/unknownutil@4.3.0";
+export type RecipePage = {
+  name: string;
+  options?: Record<string, unknown> | undefined;
+};
 
-const recipePage = is.ObjectOf({
-  name: is.String,
-  options: as.Optional(is.ObjectOf({})),
-});
-
-export const validate = is.ObjectOf({
-  collector: recipePage,
-  processor: is.ArrayOf(recipePage),
-  emitter: recipePage,
-});
-
-export type Recipe = PredicateType<typeof validate>;
+export type Recipe = {
+  collector: RecipePage;
+  processor: RecipePage[];
+  emitter: RecipePage;
+};
 
 export type Kind = "collector" | "processor" | "emitter";
 

--- a/denops/tataku/validate.ts
+++ b/denops/tataku/validate.ts
@@ -3,7 +3,7 @@ import type { Recipe, RecipePage } from "./types.ts";
 
 const recipePage = is.ObjectOf({
   name: is.String,
-  options: as.Optional(is.ObjectOf({})),
+  options: as.Optional(is.Record),
 }) satisfies Predicate<RecipePage>;
 
 export const validate = is.ObjectOf({

--- a/denops/tataku/validate.ts
+++ b/denops/tataku/validate.ts
@@ -1,0 +1,13 @@
+import { as, is, type Predicate } from "jsr:@core/unknownutil@4.3.0";
+import type { Recipe, RecipePage } from "./types.ts";
+
+const recipePage = is.ObjectOf({
+  name: is.String,
+  options: as.Optional(is.ObjectOf({})),
+}) satisfies Predicate<RecipePage>;
+
+export const validate = is.ObjectOf({
+  collector: recipePage,
+  processor: is.ArrayOf(recipePage),
+  emitter: recipePage,
+}) satisfies Predicate<Recipe>;

--- a/jsr.json
+++ b/jsr.json
@@ -7,7 +7,8 @@
     "include": [
       "README.md",
       "LICENSE",
-      "denops/**/*.ts"
+      "denops/tataku/export.ts",
+      "denops/tataku/types.ts"
     ],
     "exclude": [
       "internal"


### PR DESCRIPTION
unknownutil suggest to use `Predicate` and write type by myself.

ref: https://jsr.io/@core/unknownutil/doc/~/Predicate

It make reduce `slow-types` warning by `deno publish`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new validation mechanism for recipe data structures.
	- Enhanced type safety for recipe-related configurations.

- **Refactor**
	- Migrated from runtime validation to compile-time type checking.
	- Simplified type definitions for recipes and recipe pages.

- **Chores**
	- Updated project configuration to include specific TypeScript files during publishing.
	- Adjusted release workflow to streamline the publishing process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->