### PR TITLE
refactor: refactor error util function

### DIFF
--- a/autoload/tataku/util.vim
+++ b/autoload/tataku/util.vim
@@ -1,16 +1,19 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-function! tataku#util#echo_error(msg) abort
-  const l:error_message = printf('[tataku] %s', type(a:msg) ==# v:t_string ? a:msg : string(a:msg))
-  if has('nvim')
+if has('nvim')
+  function! tataku#util#echo_error(msg) abort
+    const l:error_message = printf('[tataku] %s', type(a:msg) ==# v:t_string ? a:msg : string(a:msg))
     call luaeval('vim.notify(_A, vim.log.levels.ERROR)', l:error_message)
-  else
+  endfunction
+else
+  function! tataku#util#echo_error(msg) abort
+    const l:error_message = printf('[tataku] %s', type(a:msg) ==# v:t_string ? a:msg : string(a:msg))
     echohl ErrorMsg
     echomsg l:error_message
     echohl None
-  endif
-endfunction
+  endfunction
+endif
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/autoload/tataku/util.vim
+++ b/autoload/tataku/util.vim
@@ -2,12 +2,12 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! tataku#util#echo_error(msg) abort
-  let g:_tataku_internal_error_message = printf('[tataku] %s', type(a:msg) ==# v:t_string ? a:msg : string(a:msg))
+  const l:error_message = printf('[tataku] %s', type(a:msg) ==# v:t_string ? a:msg : string(a:msg))
   if has('nvim')
-    lua vim.notify(vim.g._tataku_internal_error_message, vim.log.levels.ERROR)
+    call luaeval('vim.notify(_A, vim.log.levels.ERROR)', l:error_message)
   else
     echohl ErrorMsg
-    echomsg g:_tataku_internal_error_message
+    echomsg l:error_message
     echohl None
   endif
 endfunction


### PR DESCRIPTION
- stop to use `g:` scope variable
- reduce `has` function evaluate times


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error reporting mechanism across different Vim environments
	- Enhanced error message handling to use environment-specific notification methods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->